### PR TITLE
Fix Shuffle Task Saving Parameter Type

### DIFF
--- a/src/Magewire/ListShuffle.php
+++ b/src/Magewire/ListShuffle.php
@@ -40,7 +40,7 @@ class ListShuffle extends Component
 
         if ($this->getMarkAsDone()) {
             $title = 'List shuffle (' . join(',', $entities) . ')';
-            $this->emitTo('magewire.todo-checklist', 'todo:finish', [$title]);
+            $this->emitTo('magewire.todo-checklist', 'todo:finish', $title);
         }
     }
 }


### PR DESCRIPTION
# Description
The TodoChecklist component's saveTask() function expects a string parameter but the ListShuffle component provides an array - resulting in an exception being thrown.
